### PR TITLE
Move format_phone_number callback to before_validation

### DIFF
--- a/app/models/contact.rb
+++ b/app/models/contact.rb
@@ -1,6 +1,7 @@
 class Contact
   include Mongoid::Document
-  before_save :format_phone_number, :update_international
+  before_validation :format_phone_number
+  before_save :update_international
 
   # I'd normally set this up to allow a contact to have multiple email addresses or phone numbers
   # but given the scope of the assignment it doesn't seem necessary.


### PR DESCRIPTION
1. Change format_phone_number callback from before_save to before_validation to ensure the final formatted phonenumber is used in uniqueness validation
